### PR TITLE
feat: 마이페이지, 수정페이지, 프로젝트 등록페이지 작업 머지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-popover": "^1.1.1",
         "@radix-ui/react-radio-group": "^1.2.0",
+        "@radix-ui/react-select": "^2.1.4",
         "@radix-ui/react-slot": "^1.1.0",
         "@suspensive/react": "^2.18.7",
         "@tanstack/react-query": "^5.56.2",
@@ -876,6 +877,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
+      "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
@@ -1167,94 +1174,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-popover/node_modules/react-remove-scroll/node_modules/react-remove-scroll-bar": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
-      "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
-      "license": "MIT",
-      "dependencies": {
-        "react-style-singleton": "^2.2.1",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popover/node_modules/react-remove-scroll/node_modules/react-style-singleton": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
-      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
-      "license": "MIT",
-      "dependencies": {
-        "get-nonce": "^1.0.0",
-        "invariant": "^2.2.4",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popover/node_modules/react-remove-scroll/node_modules/use-callback-ref": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
-      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-popover/node_modules/react-remove-scroll/node_modules/use-sidecar": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
-      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.0.tgz",
@@ -1420,6 +1339,298 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.4.tgz",
+      "integrity": "sha512-pOkb2u8KgO47j/h7AylCj7dJsm69BXcjkrvTqMptFqsE2i0p8lHkfgneXKjAgPzBMivnoMyt8o4KiV4wYzDdyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.3",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.1",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.1",
+        "@radix-ui/react-portal": "1.1.3",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-slot": "1.1.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.1",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "^2.6.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.1.tgz",
+      "integrity": "sha512-NaVpZfmv8SKeZbn4ijN2V3jlHA9ngBG16VnIIm22nUR0Yk8KUALyBxT3KYEUnNuch9sTE8UTsS3whzBgKOL30w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.1.tgz",
+      "integrity": "sha512-LwT3pSho9Dljg+wY2KN2mrrh6y3qELfftINERIzBUO9e0N+t0oMTyn3k9iv+ZqgrwGkRnLpNJrsMv9BZlt2yuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.3.tgz",
+      "integrity": "sha512-onrWn/72lQoEucDmJnr8uczSNTujT0vJnA/X5+3AkChVPowr8n1yvIKIabhWyMQeMvvmdpsvcyDqx3X1LEXCPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
+      "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.1.tgz",
+      "integrity": "sha512-01omzJAYRxXdG2/he/+xy+c8a8gCydoQ1yOxnWNcRhrrBW5W+RQJ22EK1SaO8tb3WoUsuEw7mJjBozPzihDFjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.1.tgz",
+      "integrity": "sha512-3kn5Me69L+jv82EKRuQCXdYyf1DqHwD2U/sxoNgBGCB7K9TRc3bQamQ+5EPM9EvyPdli0W41sROd+ZU1dTCztw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.3.tgz",
+      "integrity": "sha512-NciRqhXnGojhT93RPyDaMPfLH3ZSl4jjIFbZQ1b/vxvZEdHsBZ49wP9w8L3HzUQwep01LcWtkUvm0OVB5JAHTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
+      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
+      "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
@@ -1538,6 +1749,85 @@
       "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.1.tgz",
+      "integrity": "sha512-vVfA2IZ9q/J+gEamvj761Oq1FpWgCDaNOOIfbPVp2MVPLEomUr5+Vf7kJGwQ24YxZSlQVar7Bes8kyTo5Dshpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
+      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
+      "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3987,15 +4277,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/is-array-buffer": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
@@ -5358,6 +5639,75 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.2.tgz",
+      "integrity": "sha512-KmONPx5fnlXYJQqC62Q+lwIeAk64ws/cUw6omIumRzMRPqgnYqhSSti99nbj0Ry13bv7dF+BKn7NB+OqkdZGTw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -6321,6 +6671,49 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.1",
     "@radix-ui/react-radio-group": "^1.2.0",
+    "@radix-ui/react-select": "^2.1.4",
     "@radix-ui/react-slot": "^1.1.0",
     "@suspensive/react": "^2.18.7",
     "@tanstack/react-query": "^5.56.2",

--- a/src/app/(route)/(main)/_components/Projects.tsx
+++ b/src/app/(route)/(main)/_components/Projects.tsx
@@ -38,11 +38,8 @@ export default Projects;
 
 const getdata = async () => {
   try {
-    await new Promise((resolve) => {
-      setTimeout(resolve, 500);
-    });
     const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/project/list`, {
-      next: { revalidate: 10 },
+      cache: 'no-store',
     });
 
     return res.json();

--- a/src/app/(route)/(main)/error.tsx
+++ b/src/app/(route)/(main)/error.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useErrorBoundaryFallbackProps } from '@suspensive/react';
+
+const Error = () => {
+  const { reset, error } = useErrorBoundaryFallbackProps();
+
+  return (
+    <div className="flex justify-center items-center flex-col">
+      <button onClick={reset}>Try again</button>
+      <span className="text-red-600">{error.message}</span>
+    </div>
+  );
+};
+
+export default Error;

--- a/src/app/(route)/(main)/page.tsx
+++ b/src/app/(route)/(main)/page.tsx
@@ -1,17 +1,23 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import Projects from './_components/Projects';
 import Header from './_components/Header';
 import Loading from './_components/Loading';
+import { Delay, ErrorBoundary, Suspense } from '@suspensive/react';
+import Error from './error';
 
-const page = () => {
+const Mainpage = () => {
   return (
     <div className="flex-col gap-6">
       <Header />
-      <Suspense fallback={<Loading />}>
-        <Projects />
-      </Suspense>
+      <ErrorBoundary fallback={<Error />}>
+        <Suspense fallback={<Loading />}>
+          <Delay ms={500} fallback={<Loading />}>
+            <Projects />
+          </Delay>
+        </Suspense>
+      </ErrorBoundary>
     </div>
   );
 };
 
-export default page;
+export default Mainpage;

--- a/src/app/(route)/modify/[id]/page.tsx
+++ b/src/app/(route)/modify/[id]/page.tsx
@@ -3,16 +3,18 @@ import { cookies } from 'next/headers';
 import { notFound } from 'next/navigation';
 import React, { Suspense, use } from 'react';
 import Content from '../_components/Content';
+import { getAtFromRt } from '@/app/_utils/api/server/reissue.server';
+import LoadingSpinner from '@/app/_components/server/LoadingSpinner';
 
-const ModifyPage = ({ params }: any) => {
-  const id = Number(params.id);
-  const post = getdata(id);
+const ModifyPage = ({ params }: { params: Promise<{ id: string }> }) => {
+  const { id } = use(params);
+  const post = getdata(Number(id));
   const data = use(post);
 
   if (!data) return notFound();
 
   return (
-    <Suspense fallback={<div>loading...</div>}>
+    <Suspense fallback={<LoadingSpinner className="w-[150px] h-[150px]" />}>
       <div className="flex-col gap-6">
         <GamzaCard title={`프로젝트 수정`} content={<Content {...data} />} />
       </div>
@@ -23,8 +25,8 @@ const ModifyPage = ({ params }: any) => {
 export default ModifyPage;
 
 const getdata = async (id: number) => {
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
+  const headers = await getAtFromRt();
+  const accessToken = headers?.get('authorization');
 
   try {
     const res = await fetch(

--- a/src/app/(route)/mypage/_components/InnerBox.tsx
+++ b/src/app/(route)/mypage/_components/InnerBox.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import ItemList from './ItemList';
 import TypeButton from '@/app/_components/client/TypeButton';
-import useUserProjects from '@/app/_hooks/query/project/useUserProject';
+import useUserProjects from '@/app/_hooks/react-query/project/useUserProject';
 
 interface Props {
   dataType?: string;

--- a/src/app/(route)/mypage/_components/Item.tsx
+++ b/src/app/(route)/mypage/_components/Item.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import MutateButton from './MutateButton';
-interface Project {
-  id: number;
-  title: string;
-  port: number;
-  file: string;
-}
-const Item = ({ ...props }: Project) => {
+import { useDeleteUserProject } from '@/app/_hooks/react-query/project/useDelete';
+
+const Item = ({ ...props }) => {
+  const { mutate } = useDeleteUserProject();
+
   return (
     <div className="flex justify-between items-center border border-stone-200 bg-white w-full h-[70px] px-5 py-3 rounded-xl">
       {/* 업로더 이름, 학과 */}
       <div className="flex gap-x-5 h-6">
-        <span>{props.id.toString().padStart(4, '0')}</span>
+        <span>{props.countId.toString().padStart(4, '0')}</span>
       </div>
 
       {/* 프로젝트 정보 */}
@@ -22,7 +20,11 @@ const Item = ({ ...props }: Project) => {
       </div>
 
       {/* 삭제 버튼 */}
-      <MutateButton value="삭제" color="text-red-400" />
+      <MutateButton
+        value="삭제"
+        color="text-red-400"
+        onClick={() => mutate(props.id)}
+      />
     </div>
   );
 };

--- a/src/app/(route)/mypage/_components/ItemList.tsx
+++ b/src/app/(route)/mypage/_components/ItemList.tsx
@@ -2,14 +2,21 @@ import React from 'react';
 import Item from './Item';
 
 interface Props {
-  list: any[];
+  list: Project[];
 }
+interface Project {
+  id: number;
+  title: string;
+  port: number;
+  file: string;
+}
+
 const ItemList = ({ list }: Props) => {
   return (
     <>
       {list.length ? (
-        list.map((item: any, idx: number) => (
-          <Item {...item} id={idx} key={idx} />
+        list.map((item, idx: number) => (
+          <Item {...item} key={item.id} countId={idx + 1} />
         ))
       ) : (
         <div className="flex justify-center items-center h-full">

--- a/src/app/(route)/mypage/_components/Loading.tsx
+++ b/src/app/(route)/mypage/_components/Loading.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@/app/_styles/loading.css';
 
 const Loading = () => {

--- a/src/app/(route)/mypage/_components/MutateButton.tsx
+++ b/src/app/(route)/mypage/_components/MutateButton.tsx
@@ -1,15 +1,17 @@
 'use client';
+
 import React from 'react';
 
 interface Props {
   value: string;
   color: string;
+  onClick: () => void;
 }
-const MutateButton = ({ value, color }: Props) => {
+const MutateButton = ({ value, color, onClick }: Props) => {
   return (
     <button
       className={`normal-button ${color} hover:shadow-inner`}
-      onClick={() => {}}
+      onClick={onClick}
     >
       {value}
     </button>

--- a/src/app/(route)/mypage/error.tsx
+++ b/src/app/(route)/mypage/error.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useErrorBoundaryFallbackProps } from '@suspensive/react';
+
+const Error = () => {
+  const { reset, error } = useErrorBoundaryFallbackProps();
+
+  return (
+    <div className="flex justify-center items-center flex-col">
+      <button onClick={reset}>Try again</button>
+      <span className="text-red-600">{error.message}</span>
+    </div>
+  );
+};
+
+export default Error;

--- a/src/app/(route)/mypage/page.tsx
+++ b/src/app/(route)/mypage/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense, use } from 'react';
 import { redirect } from 'next/navigation';
 import { getAtFromRt } from '@/app/_utils/api/server/reissue.server';
 import Loading from './loading';
@@ -8,10 +7,12 @@ import Loading from './loading';
 //   ssr: false,
 //   loading: () => <Loading />,
 // });
+import InnerBox from './_components/InnerBox';
+import { Suspense } from '@suspensive/react';
 
-const Mypage = ({ searchParams }: any) => {
-  const dataType = searchParams.type;
-  const auth = use(authCheck());
+const Mypage = async ({ searchParams }: any) => {
+  const { type } = await searchParams;
+  const auth = await authCheck();
 
   if (!auth) return redirect('/login');
 

--- a/src/app/(route)/mypage/page.tsx
+++ b/src/app/(route)/mypage/page.tsx
@@ -1,15 +1,9 @@
 import { redirect } from 'next/navigation';
 import { getAtFromRt } from '@/app/_utils/api/server/reissue.server';
-import Loading from './loading';
-// import dynamic from 'next/dynamic';
-
-// const InnerBox = dynamic(() => import('./_components/InnerBox'), {
-//   ssr: false,
-//   loading: () => <Loading />,
-// });
-import InnerBox from './_components/InnerBox';
 import { ErrorBoundary, Suspense } from '@suspensive/react';
+import InnerBox from './_components/InnerBox';
 import Error from './error';
+import Loading from './_components/Loading';
 
 const Mypage = async ({ searchParams }: any) => {
   const { type } = await searchParams;
@@ -30,5 +24,5 @@ export default Mypage;
 
 const authCheck = async () => {
   const resHeader = await getAtFromRt();
-  return resHeader;
+  return !!resHeader;
 };

--- a/src/app/(route)/mypage/page.tsx
+++ b/src/app/(route)/mypage/page.tsx
@@ -8,7 +8,8 @@ import Loading from './loading';
 //   loading: () => <Loading />,
 // });
 import InnerBox from './_components/InnerBox';
-import { Suspense } from '@suspensive/react';
+import { ErrorBoundary, Suspense } from '@suspensive/react';
+import Error from './error';
 
 const Mypage = async ({ searchParams }: any) => {
   const { type } = await searchParams;
@@ -17,9 +18,11 @@ const Mypage = async ({ searchParams }: any) => {
   if (!auth) return redirect('/login');
 
   return (
-    <Suspense fallback={<Loading />}>
-      {/* <InnerBox dataType={dataType} /> */}
-    </Suspense>
+    <ErrorBoundary fallback={<Error />}>
+      <Suspense clientOnly fallback={<Loading />}>
+        <InnerBox dataType={type} />
+      </Suspense>
+    </ErrorBoundary>
   );
 };
 

--- a/src/app/(route)/post/_components/process/Second.tsx
+++ b/src/app/(route)/post/_components/process/Second.tsx
@@ -1,4 +1,8 @@
-import { RHFCalendar, RHFRadioGroup } from '@/app/_components/client/RHF';
+import {
+  RHFCalendar,
+  RHFListSelector,
+  RHFRadioGroup,
+} from '@/app/_components/client/RHF';
 import { CardButton } from '@/app/_components/server/GamzaCard';
 import React from 'react';
 
@@ -31,6 +35,18 @@ const Second = () => {
           ]}
         />
         <RHFCalendar name="date" label="프로젝트 기간" id="date" />
+        <RHFListSelector
+          name="collaborators"
+          label="공동 작업자"
+          userList={[
+            { id: 1, name: '동균', studentId: '201910050' },
+            { id: 2, name: '효성', studentId: '201910052' },
+            { id: 3, name: '성훈', studentId: '201910051' },
+            { id: 4, name: '이삭', studentId: '200710060' },
+            { id: 5, name: '지현', studentId: '202010050' },
+            { id: 6, name: '호빈', studentId: '202010011' },
+          ]}
+        />
       </div>
       <div className="flex justify-end gap-x-3">
         <CardButton text="이전" value="prev" />

--- a/src/app/(route)/post/_components/process/Second.tsx
+++ b/src/app/(route)/post/_components/process/Second.tsx
@@ -4,9 +4,12 @@ import {
   RHFRadioGroup,
 } from '@/app/_components/client/RHF';
 import { CardButton } from '@/app/_components/server/GamzaCard';
+import { useUserList } from '@/app/_hooks/react-query/user/useUserList';
 import React from 'react';
 
 const Second = () => {
+  const { data } = useUserList();
+
   return (
     <div className="flex flex-col gap-y-5">
       <div className="flex flex-col gap-y-6 py-7">
@@ -38,14 +41,7 @@ const Second = () => {
         <RHFListSelector
           name="collaborators"
           label="공동 작업자"
-          userList={[
-            { id: 1, name: '동균', studentId: '201910050' },
-            { id: 2, name: '효성', studentId: '201910052' },
-            { id: 3, name: '성훈', studentId: '201910051' },
-            { id: 4, name: '이삭', studentId: '200710060' },
-            { id: 5, name: '지현', studentId: '202010050' },
-            { id: 6, name: '호빈', studentId: '202010011' },
-          ]}
+          userList={data.userList}
         />
       </div>
       <div className="flex justify-end gap-x-3">

--- a/src/app/(route)/post/_components/process/Second.tsx
+++ b/src/app/(route)/post/_components/process/Second.tsx
@@ -12,38 +12,41 @@ const Second = () => {
 
   return (
     <div className="flex flex-col gap-y-5">
-      <div className="flex flex-col gap-y-6 py-7">
-        <RHFRadioGroup
-          name="status"
-          label="상태"
-          itemList={[
-            {
-              value: 'PLAN',
-              id: 'PLAN',
-              title: '계획',
-              disalbed: true,
-            },
-            {
-              value: 'PROGRESS',
-              id: 'PROGRESS',
-              title: '진행',
-              disalbed: true,
-            },
-            {
-              value: 'DONE',
-              id: 'DONE',
-              title: '완료',
-              checked: true,
-            },
-          ]}
-        />
-        <RHFCalendar name="date" label="프로젝트 기간" id="date" />
-        <RHFListSelector
-          name="collaborators"
-          label="공동 작업자"
-          userList={data.userList}
-        />
-      </div>
+      {data && (
+        <div className="flex flex-col gap-y-6 py-7">
+          <RHFRadioGroup
+            name="status"
+            label="상태"
+            itemList={[
+              {
+                value: 'PLAN',
+                id: 'PLAN',
+                title: '계획',
+                disalbed: true,
+              },
+              {
+                value: 'PROGRESS',
+                id: 'PROGRESS',
+                title: '진행',
+                disalbed: true,
+              },
+              {
+                value: 'DONE',
+                id: 'DONE',
+                title: '완료',
+                checked: true,
+              },
+            ]}
+          />
+          <RHFCalendar name="date" label="프로젝트 기간" id="date" />
+          <RHFListSelector
+            name="collaborators"
+            label="공동 작업자"
+            userList={data.userList}
+          />
+        </div>
+      )}
+
       <div className="flex justify-end gap-x-3">
         <CardButton text="이전" value="prev" />
         <CardButton text="다음" color="green" value="next" />

--- a/src/app/(route)/post/_components/process/index.tsx
+++ b/src/app/(route)/post/_components/process/index.tsx
@@ -7,6 +7,7 @@ import Third from './Third';
 import { PostSchema } from '@/app/_utils/validator/post';
 import { useFormFunnel } from '@/app/_hooks/funnel/useFormFunnel';
 import { usePostForm } from '@/app/_hooks/react-query/project/usePost';
+import { Collaborator } from '@/app/_types/RHFProps';
 
 const Process = () => {
   const { FormFunnel, setStep } = useFormFunnel<'First' | 'Second' | 'Third'>(
@@ -46,6 +47,9 @@ const Process = () => {
             port: data.port,
             v_key: data.v_key,
             tag: data.tag,
+            collaborators: data.collaborators.map(
+              (item: Collaborator) => item.id
+            ),
           })
         }
         onPrev={() => setStep('Second')}

--- a/src/app/(route)/post/page.tsx
+++ b/src/app/(route)/post/page.tsx
@@ -1,8 +1,13 @@
 import GamzaCard from '@/app/_components/server/GamzaCard';
 import React from 'react';
 import Process from './_components/process';
+import { getAtFromRt } from '@/app/_utils/api/server/reissue.server';
+import { redirect } from 'next/navigation';
 
-const page = () => {
+const Postpage = async () => {
+  const auth = await authCheck();
+  if (!auth) redirect('/login');
+
   return (
     <div className="flex-col gap-6">
       <GamzaCard title={`프로젝트 등록 페이지`} content={<Process />} />
@@ -10,4 +15,9 @@ const page = () => {
   );
 };
 
-export default page;
+export default Postpage;
+
+const authCheck = async () => {
+  const resHeader = await getAtFromRt();
+  return !!resHeader;
+};

--- a/src/app/_components/client/RHF/index.tsx
+++ b/src/app/_components/client/RHF/index.tsx
@@ -390,27 +390,38 @@ export const RHFListSelector = ({
               >
                 <FormControl className="w-[225px] bg-white">
                   <SelectTrigger>
-                    <SelectValue placeholder="사용자를 선택해 주세요." />
+                    <input
+                      placeholder="유저를 선택해 주세요."
+                      defaultValue={'유저를 선택해 주세요.'}
+                      type="button"
+                      className="hover:cursor-pointer"
+                    />
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent className="bg-white max-h-[130px] h-auto">
-                  {users.map((user) => (
-                    <SelectItem
-                      key={user.id}
-                      value={String(user.id)}
-                      className="hover:bg-gray-100 hover:cursor-pointer"
-                    >
-                      <div className="flex gap-3">
-                        <Image
-                          src={'/Logo.svg'}
-                          alt="감자"
-                          width={20}
-                          height={20}
-                        />
-                        <span>{`${user.name} (${user.studentId})`}</span>
-                      </div>
-                    </SelectItem>
-                  ))}
+                  {users.length ? (
+                    users.map((user) => (
+                      <SelectItem
+                        key={user.id}
+                        value={String(user.id)}
+                        className="hover:bg-gray-100 hover:cursor-pointer"
+                      >
+                        <div className="flex gap-3">
+                          <Image
+                            src={'/Logo.svg'}
+                            alt="감자"
+                            width={20}
+                            height={20}
+                          />
+                          <span>{`${user.name} (${user.studentId})`}</span>
+                        </div>
+                      </SelectItem>
+                    ))
+                  ) : (
+                    <div className="flex justify-center items-center p-[20px_10px] text-[13px] font-bold">
+                      선택할 유저가 없습니다.
+                    </div>
+                  )}
                 </SelectContent>
               </Select>
             </div>

--- a/src/app/_components/client/RHF/index.tsx
+++ b/src/app/_components/client/RHF/index.tsx
@@ -13,6 +13,7 @@ import {
   RHFCalendarProps,
   RHFFileInputProps,
   RHFCheckBoxProps,
+  RHFListSelectorProps,
 } from '@/app/_types/RHFProps';
 import { Label } from '@/app/_components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/app/_components/ui/radio-group';
@@ -21,7 +22,7 @@ import { Calendar as CalendarIcon } from 'lucide-react';
 import { cn } from '@/app/_utils/utils';
 import { Button } from '@/app/_components/ui/button';
 import { Calendar } from '@/app/_components/ui/calendar';
-import { Checkbox } from '../../ui/checkbox';
+import { Checkbox } from '@/app/_components/ui/checkbox';
 import {
   Popover,
   PopoverContent,
@@ -30,6 +31,15 @@ import {
 import { FileInput, NormalInput } from './ui';
 import { useFormContext } from 'react-hook-form';
 import { useEffect } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/app/_components/ui/select';
+import CollaboratorList from './ui/CollaboratorList';
+import Image from 'next/image';
 
 export const RHFWrapper = ({
   children,
@@ -233,6 +243,7 @@ export const RHFCalendar = ({
     control,
     formState: { errors },
     setValue,
+    watch,
   } = useFormContext();
 
   useEffect(() => {
@@ -328,6 +339,78 @@ export const RHFCheckbox = ({ name, label }: RHFCheckBoxProps) => {
             <RHFErrorSpan message={errors[name]?.message} />
           )}
         </FormItem>
+      )}
+    />
+  );
+};
+
+export const RHFListSelector = ({
+  name,
+  label,
+  userList,
+  defaultValue,
+}: RHFListSelectorProps) => {
+  const {
+    control,
+    formState: { errors },
+    setValue,
+    watch,
+  } = useFormContext();
+
+  useEffect(() => {
+    if (defaultValue) {
+      setValue(name, defaultValue);
+    }
+  }, [defaultValue, name, setValue]);
+
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <div className="flex flex-col gap-1">
+          <FormItem className="flex gap-x-10 items-center w-full justify-center">
+            <FormLabel className="w-[88px] font-normal text-[rgba(0,0,0,0.6)] text-sm">
+              {label}
+            </FormLabel>
+            <div className="flex flex-col gap-1">
+              <Select
+                onValueChange={(value) => {
+                  const user = userList.find(
+                    (item) => item.id === Number(value)
+                  );
+                  if (user) field.onChange([...field.value, user]);
+                }}
+              >
+                <FormControl className="w-[225px] bg-white">
+                  <SelectTrigger>
+                    <SelectValue placeholder="사용자를 선택해 주세요." />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent className="bg-white h-[120px]">
+                  {userList.map((user) => (
+                    <SelectItem
+                      key={user.id}
+                      value={String(user.id)}
+                      className="hover:bg-gray-100 hover:cursor-pointer"
+                    >
+                      <div className="flex gap-3">
+                        <Image
+                          src={'/Logo.svg'}
+                          alt="감자"
+                          width={20}
+                          height={20}
+                        />
+                        <span>{`${user.name} (${user.studentId})`}</span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </FormItem>
+          <CollaboratorList field={field} selectUsers={watch().collaborators} />
+        </div>
       )}
     />
   );

--- a/src/app/_components/client/RHF/index.tsx
+++ b/src/app/_components/client/RHF/index.tsx
@@ -14,6 +14,7 @@ import {
   RHFFileInputProps,
   RHFCheckBoxProps,
   RHFListSelectorProps,
+  Collaborator,
 } from '@/app/_types/RHFProps';
 import { Label } from '@/app/_components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/app/_components/ui/radio-group';
@@ -363,6 +364,13 @@ export const RHFListSelector = ({
     }
   }, [defaultValue, name, setValue]);
 
+  const users = userList.filter(
+    (user) =>
+      !watch()
+        .collaborators.map((item: Collaborator) => item.id)
+        .includes(user.id)
+  );
+
   return (
     <FormField
       control={control}
@@ -376,9 +384,7 @@ export const RHFListSelector = ({
             <div className="flex flex-col gap-1">
               <Select
                 onValueChange={(value) => {
-                  const user = userList.find(
-                    (item) => item.id === Number(value)
-                  );
+                  const user = users.find((item) => item.id === Number(value));
                   if (user) field.onChange([...field.value, user]);
                 }}
               >
@@ -387,8 +393,8 @@ export const RHFListSelector = ({
                     <SelectValue placeholder="사용자를 선택해 주세요." />
                   </SelectTrigger>
                 </FormControl>
-                <SelectContent className="bg-white h-[120px]">
-                  {userList.map((user) => (
+                <SelectContent className="bg-white max-h-[130px] h-auto">
+                  {users.map((user) => (
                     <SelectItem
                       key={user.id}
                       value={String(user.id)}

--- a/src/app/_components/client/RHF/ui/CollaboratorList.tsx
+++ b/src/app/_components/client/RHF/ui/CollaboratorList.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Collaborator } from '@/app/_types/RHFProps';
+import Image from 'next/image';
+import React from 'react';
+import { ControllerRenderProps } from 'react-hook-form';
+
+interface Props {
+  field: ControllerRenderProps;
+  selectUsers: Collaborator[];
+}
+
+const CollaboratorList = (props: Props) => {
+  const { field, selectUsers } = props;
+
+  if (!selectUsers.length) return null;
+
+  return (
+    <div className="flex flex-col gap-1 mt-1 items-center">
+      {selectUsers.map((user) => {
+        return (
+          <div
+            key={user.id}
+            className="w-full bg-gray-100 text-[#697183] font-semibold rounded-[14px] text-[12px] flex justify-between p-[5px_12px] hover:bg-gray-200 max-w-[225px] ml-[130px]"
+          >
+            <span>{`✅ ${user.name} (${user.studentId})`}</span>
+            <button
+              onClick={() => {
+                const filterArr = field.value.filter(
+                  (item: Collaborator) => item.id !== user.id
+                );
+                field.onChange([...filterArr]);
+              }}
+            >
+              <Image src="/Close.svg" width={14} height={14} alt="close" />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default CollaboratorList;

--- a/src/app/_components/ui/select.tsx
+++ b/src/app/_components/ui/select.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import * as React from 'react';
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { Check, ChevronDown, ChevronUp } from 'lucide-react';
+
+import { cn } from '@/app/_utils/utils';
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      'flex cursor-default items-center justify-center py-1',
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      'flex cursor-default items-center justify-center py-1',
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = 'popper', ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        position === 'popper' &&
+          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectPrimitive.Viewport
+        className={cn(
+          'p-1',
+          position === 'popper' &&
+            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn('py-1.5 pl-8 pr-2 text-sm font-semibold', className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 px-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className
+    )}
+    {...props}
+  >
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+};

--- a/src/app/_hooks/react-query/project/useDelete.ts
+++ b/src/app/_hooks/react-query/project/useDelete.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deleteProject } from '@/app/api/(end-point)/project/delete';
+
+export const useDeleteUserProject = () => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation({
+    mutationKey: ['deleteUserProject'],
+    mutationFn: (id: number) => deleteProject(id),
+    onSuccess: () => {
+      alert('프로젝트가 삭제되었습니다.');
+      queryClient.refetchQueries({
+        queryKey: ['/project/user/list', localStorage.getItem('accessToken')],
+      });
+    },
+    onError: (error) => {
+      alert('잠시후에 다시 시도해주세요.');
+    },
+  });
+
+  return { mutate };
+};

--- a/src/app/_hooks/react-query/project/usePost.ts
+++ b/src/app/_hooks/react-query/project/usePost.ts
@@ -16,6 +16,7 @@ export const usePostForm = () => {
       port,
       v_key,
       tag,
+      collaborators,
     }: PostForm) =>
       createProject({
         zip,
@@ -26,6 +27,7 @@ export const usePostForm = () => {
         port,
         v_key,
         tag,
+        collaborators,
       }),
     onSuccess: () => {
       alert(

--- a/src/app/_hooks/react-query/project/useUserProject.ts
+++ b/src/app/_hooks/react-query/project/useUserProject.ts
@@ -2,8 +2,9 @@ import { getUserProject } from '@/app/_utils/api/mypage';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 const useUserProjects = () => {
+  const accessToken = localStorage.getItem('accessToken');
   const { data } = useSuspenseQuery({
-    queryKey: ['user'],
+    queryKey: ['/project/user/list', accessToken],
     queryFn: () => getUserProject(),
   });
 

--- a/src/app/_hooks/react-query/user/useUserList.ts
+++ b/src/app/_hooks/react-query/user/useUserList.ts
@@ -1,0 +1,16 @@
+import apiClient from '@/app/_utils/api/apiClient';
+import { useQuery } from '@tanstack/react-query';
+
+const getUserList = async () => {
+  const res = await apiClient('/user/list');
+  return res;
+};
+
+export const useUserList = () => {
+  const { data } = useQuery({
+    queryKey: ['userList'],
+    queryFn: () => getUserList(),
+  });
+
+  return { data: data?.data };
+};

--- a/src/app/_types/RHFProps.ts
+++ b/src/app/_types/RHFProps.ts
@@ -68,3 +68,15 @@ export interface RHFCheckBoxProps {
   name: string;
   label: string;
 }
+
+export type Collaborator = {
+  id: number;
+  name: string;
+  studentId: string;
+};
+export interface RHFListSelectorProps {
+  name: string;
+  label: string;
+  userList: Collaborator[];
+  defaultValue?: Collaborator[];
+}

--- a/src/app/_utils/api/server/reissue.server.ts
+++ b/src/app/_utils/api/server/reissue.server.ts
@@ -12,6 +12,8 @@ export const getAtFromRt = async () => {
       next: { revalidate: 3600 },
     });
 
+    if (res.status === 500 || res.status === 401) return;
+
     return res.headers;
   } catch (err) {
     console.log('error!');

--- a/src/app/_utils/api/server/reissue.server.ts
+++ b/src/app/_utils/api/server/reissue.server.ts
@@ -1,7 +1,8 @@
 import { cookies } from 'next/headers';
 
 export const getAtFromRt = async () => {
-  const refresh = (await cookies()).get('refreshToken')?.value;
+  const cookie = await cookies();
+  const refresh = cookie.get('refreshToken')?.value;
 
   try {
     const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/user/reissue`, {

--- a/src/app/_utils/validator/post.ts
+++ b/src/app/_utils/validator/post.ts
@@ -3,6 +3,12 @@ import { z } from 'zod';
 const MAX_FILE_SIZE = 200000000;
 const ACCEPTED_FILE_TYPES = ['application/zip'];
 
+const collaboratorSchema = z.object({
+  id: z.number().default(0),
+  name: z.string().default(''),
+  studentId: z.string().default(''),
+});
+
 export const PostSchema = {
   first: z.object({
     title: z
@@ -40,6 +46,7 @@ export const PostSchema = {
         }
       )
       .default({ from: null, to: null }),
+    collaborators: z.array(collaboratorSchema).default([]),
   }),
   third: z.object({
     file:

--- a/src/app/api/(end-point)/project/delete.ts
+++ b/src/app/api/(end-point)/project/delete.ts
@@ -1,0 +1,6 @@
+import apiClient from '@/app/_utils/api/axiosClient';
+
+export const deleteProject = async (projectId: number) => {
+  const res = await apiClient.delete(`/project/user/list/${projectId}`);
+  return res;
+};

--- a/src/app/api/(end-point)/project/delete.ts
+++ b/src/app/api/(end-point)/project/delete.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/app/_utils/api/axiosClient';
+import apiClient from '@/app/_utils/api/apiClient';
 
 export const deleteProject = async (projectId: number) => {
   const res = await apiClient.delete(`/project/user/list/${projectId}`);

--- a/src/app/api/(end-point)/project/post.ts
+++ b/src/app/api/(end-point)/project/post.ts
@@ -16,6 +16,7 @@ export const createProject = async ({ ...props }: PostForm) => {
     variableKey: props.v_key || '',
     applicationType: 'CLIENT',
     applicationName: props.title,
+    collaborators: JSON.stringify(props.collaborators),
   };
 
   Object.entries(fields).forEach(([key, value]) => {

--- a/src/app/api/(end-point)/project/post.ts
+++ b/src/app/api/(end-point)/project/post.ts
@@ -14,9 +14,7 @@ export const createProject = async ({ ...props }: PostForm) => {
     outerPort: props.port,
     tag: props.tag,
     variableKey: props.v_key || '',
-    applicationType: 'CLIENT',
-    applicationName: props.title,
-    collaborators: JSON.stringify(props.collaborators),
+    collaborators: props.collaborators.join(','),
   };
 
   Object.entries(fields).forEach(([key, value]) => {

--- a/src/app/api/(end-point)/project/project.type.ts
+++ b/src/app/api/(end-point)/project/project.type.ts
@@ -12,6 +12,7 @@ export type PostForm = {
   port: string;
   v_key: string | null;
   tag: string;
+  collaborators: number[];
 };
 
 export type ModifyForm = {


### PR DESCRIPTION
## 🚀 반영 브랜치
`post` → `develop`

<br/>

## ✅ 작업 내용
- **마이페이지**
  - suspensive/react 적용한 마이페이지 데이터 fetching 구현
  - 서버에서 auth 관련 로직 처리시 불필요한 loading 컴포넌트 제거
  - 유저 프로젝트 삭제 mutate 액션 구현
- **수정페이지**
  - 수정페이지 페이지 접근을 위한 accessToken 받아오는 방식 변경
- **프로젝트 등록 페이지**
  -shadcn ui Select install
  - collaborators 추가에 따른 zod 스키마 변경 및 타입 정의, Select UI 구현
  - /user/list GET API 연동
  - Collaborators auto height 추가, 전달 인수 string 값으로 변경

<br/>

## 🌠 이미지 첨부

![스크린샷 2025-01-15 오후 11 57 48](https://github.com/user-attachments/assets/81760a10-4844-4a26-a149-5d845d93ec75)

<br/>


## 📌 이슈 링크

- #45 
